### PR TITLE
[fix] 망치 콜라이더 수정 및 사망 로직 변경

### DIFF
--- a/Assets/Resources/Prefabs/Player/Player.prefab
+++ b/Assets/Resources/Prefabs/Player/Player.prefab
@@ -764,14 +764,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0605f1fdbe3ebe4287633cdf3bd3111, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  currentHP: 2
+  currentHP: 4
   maxStamina: 100
   currentStamina: 100
   staminaConstant: 10
   _hammerCollider: {fileID: 1593777574002791125}
   _StaminaSlider: {fileID: 0}
-  _HpSprite1: {fileID: 0}
-  _HpSprite2: {fileID: 0}
+  _HpPrefab: {fileID: 9201929418238652806, guid: 9094a618ef88bef4097e030e75808a8c, type: 3}
 --- !u!114 &13467684890913852
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SamplePlayerScene.unity
+++ b/Assets/Scenes/SamplePlayerScene.unity
@@ -775,9 +775,10 @@ GameObject:
   m_Component:
   - component: {fileID: 1688515386}
   - component: {fileID: 1688515387}
+  - component: {fileID: 1688515388}
   m_Layer: 0
   m_Name: Capsule
-  m_TagString: Untagged
+  m_TagString: EnemyAttack
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -849,6 +850,41 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!70 &1688515388
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1688515385}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 1, y: 2}
+  m_Direction: 0
 --- !u!1 &1691890228
 GameObject:
   m_ObjectHideFlags: 0
@@ -1324,22 +1360,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
-      propertyPath: _HpPrefab
-      value: 
-      objectReference: {fileID: 9201929418238652806, guid: 9094a618ef88bef4097e030e75808a8c, type: 3}
-    - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
-      propertyPath: currentHP
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
-      propertyPath: _HpSprite1
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
-      propertyPath: _HpSprite2
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
       propertyPath: _StaminaSlider
       value: 

--- a/Assets/Scripts/Player/Action/Attack.cs
+++ b/Assets/Scripts/Player/Action/Attack.cs
@@ -121,8 +121,10 @@ public class Attack : MonoBehaviour
         Debug.Log("State : Basic Attack");
         _animator.SetBool("doNormalAttack", true);
         _animator.SetBool("doAttack", false);
+
+        yield return new WaitForSeconds(0.1f);
         _hammerCollider.SetActive(true);
-        yield return new WaitForSeconds(0.4f);
+        yield return new WaitForSeconds(0.3f);
         _perlin.m_AmplitudeGain = 0.3f;
         _perlin.m_FrequencyGain = 1f;
         yield return new WaitForSeconds(0.2f);

--- a/Assets/Scripts/Player/Action/Damaged.cs
+++ b/Assets/Scripts/Player/Action/Damaged.cs
@@ -95,7 +95,7 @@ public class Damaged : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.CompareTag("EnemyAttack"))
+        if (collision.CompareTag("EnemyAttack") && _playerController.playerContext.GetState().GetType() != typeof(DeadState))
             OnDamaged();
     }
 }


### PR DESCRIPTION
- 기본 공격 망치 콜라이더를 살짝 늦게 활성화되도록 수정
- 죽은 상태에서는 데미지를 입지 않도록 수정