### PR TITLE
[fix] 수치 밸런스 조정 外 

### DIFF
--- a/Assets/Resources/Prefabs/Player/Player.prefab
+++ b/Assets/Resources/Prefabs/Player/Player.prefab
@@ -826,12 +826,12 @@ MonoBehaviour:
   usingStamina: 0
   maxStamina: 100
   currentStamina: 100
-  staminaConstant: 10
+  staminaConstant: 50
   normalAttackDamage: 10
   normalAttackComboDamage: 6
   normalAttackLastComboDamage: 15
-  chargeAttackDamage: 20
-  fullChargeAttackDamage: 30
+  chargeAttackDamage: 25
+  fullChargeAttackDamage: 50
   _hammerCollider: {fileID: 1593777574002791125}
   _StaminaSlider: {fileID: 0}
   _HpSlider: {fileID: 0}
@@ -854,8 +854,8 @@ MonoBehaviour:
   attackByUsingBuffer: 0
   attackReadyStamina: 10
   normalAttackStamina: 10
-  chargeAttackStamina: 15
-  fullChargeAttackStamina: 20
+  chargeAttackStamina: 35
+  fullChargeAttackStamina: 60
   pressStart: 0
   _hammerCollider: {fileID: 1593777574002791125}
 --- !u!114 &5192798174603766178
@@ -884,7 +884,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DodgeDistance: 10
   dodgeTimerLimit: 0.5
-  dodgeStamina: 20
+  dodgeStamina: 25
 --- !u!114 &2414681908965708044
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SamplePlayerScene.unity
+++ b/Assets/Scenes/SamplePlayerScene.unity
@@ -2041,6 +2041,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 13467684890913852, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
+      propertyPath: chargeAttackStamina
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 13467684890913852, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
+      propertyPath: fullChargeAttackStamina
+      value: 60
+      objectReference: {fileID: 0}
     - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
       propertyPath: _HpSlider
       value: 
@@ -2049,6 +2057,22 @@ PrefabInstance:
       propertyPath: _StaminaSlider
       value: 
       objectReference: {fileID: 1882554034}
+    - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
+      propertyPath: staminaConstant
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
+      propertyPath: chargeAttackDamage
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1588757934191394853, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
+      propertyPath: fullChargeAttackDamage
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 2709649146807942217, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
+      propertyPath: dodgeStamina
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 5556207499356548342, guid: b6a41d4fb5ee6be428193aaa1aff8daa, type: 3}
       propertyPath: m_Name
       value: Player

--- a/Assets/Scripts/Player/Action/Attack.cs
+++ b/Assets/Scripts/Player/Action/Attack.cs
@@ -84,23 +84,24 @@ public class Attack : MonoBehaviour
                     _playerController.playerContext.ChangeState(IdleState.getInstance());
                     return;
                 }
-                else if(_playerController.currentStamina > attackReadyStamina + normalAttackStamina && _playerController.currentStamina < attackReadyStamina + chargeAttackStamina
+                else if(_playerController.currentStamina > attackReadyStamina + normalAttackStamina && _playerController.currentStamina < attackReadyStamina + chargeAttackStamina)
+                    //&& pressingTime > 1f)
+                {
+                    pressingButton = false;
+                    pressingTime = 0.5f;
+                }
+                else if(_playerController.currentStamina > attackReadyStamina + chargeAttackStamina && _playerController.currentStamina < attackReadyStamina + fullChargeAttackStamina
                     && pressingTime > 1f)
                 {
                     pressingButton = false;
-                    pressingTime = 1f;
-                }
-                else if(_playerController.currentStamina > attackReadyStamina + chargeAttackStamina && _playerController.currentStamina < attackReadyStamina + fullChargeAttackStamina
-                    && pressingTime > 2.5f)
-                {
-                    pressingButton = false;
-                    pressingTime = 2.5f;
+                    pressingTime = 1.5f;
                 }
                     
 
                 _body.velocity = Vector2.zero;
 
                 pressingTime += Time.deltaTime;
+                _playerController.usingStamina = true;
 
                 _animator.SetBool("doAttack", true);
                 if (pressingTime >= 5f)
@@ -179,10 +180,10 @@ public class Attack : MonoBehaviour
         {
             if (doNextComboAttack)
             {
-                if (_playerController.currentStamina >= normalAttackStamina)
+                doNextComboAttack = false; // if you want to remove combo attack buffer, take this code in front of the this "if" code;
+                if (_playerController.currentStamina >= attackReadyStamina + normalAttackStamina)
                 {
-                    doNextComboAttack = false; // if you want to remove combo attack buffer, take this code in front of the this "if" code;
-                    _playerController.currentStamina -= normalAttackStamina * 1.2f;
+                    _playerController.currentStamina -= attackReadyStamina + normalAttackStamina;
                     _playerController.usingStamina = true;
                     StartCoroutine(DoBasicAttack_Combo());
                     yield break;
@@ -230,10 +231,10 @@ public class Attack : MonoBehaviour
         {
             if (doNextComboAttack)
             {
-                if(_playerController.currentStamina >= normalAttackStamina)
+                doNextComboAttack = false; // if you want to remove combo attack buffer, take this code in front of the this "if" code;
+                if(_playerController.currentStamina >= attackReadyStamina + normalAttackStamina)
                 {
-                    doNextComboAttack = false; // if you want to remove combo attack buffer, take this code in front of the this "if" code;
-                    _playerController.currentStamina -= normalAttackStamina * 1.2f;
+                    _playerController.currentStamina -= attackReadyStamina + normalAttackStamina;
                     _playerController.usingStamina = true;
                     StartCoroutine(DoBasicAttack_LastCombo());
                     yield break;


### PR DESCRIPTION
- 스태미너 재생 0 -> 100 되는데 2초로 수정 ( staminaconstant 10 -> 50 )
- 1차 충전 데미지 20 -> 25 증가
- 2차 충전 데미지 40 -> 50 증가
- 1차 충전 공격 사용 스태미너 25 -> 45 증가
- 2차 충전 공격 사용 스태미너 40 -> 70 증가
- 회피 스태미너 20 -> 25 증가
- 달리기 스태미너 초당 20 -> 10 으로 감소
- 공격 차지 시 스태미너 차지 않도록 조정
- 공격 차지 시 현재 스태미너가 다음 차지 state의 스태미너 량을 초과하지 못하면 더 이상 충전하지 않고 현재 state 공격 바로 시전